### PR TITLE
Lv3 filename

### DIFF
--- a/joanne/Level_4/ready_ds_for_regression.py
+++ b/joanne/Level_4/ready_ds_for_regression.py
@@ -17,20 +17,11 @@ import circle_fit as cf
 yaml_directory = "/Users/geet/Documents/JOANNE/joanne/flight_segments/"
 lv3_directory = "/Users/geet/Documents/JOANNE/Data/Level_3/"
 
-lv3_files = sorted(
-    glob.glob(lv3_directory + f"EUREC4A_JOANNE_Dropsonde-RD41_Level_3_v*.nc")
-)
-
-vers = [None] * len(lv3_files)
-
-for n, i in enumerate(lv3_files):
-    vers[n] = version.parse(i)
-
-lv3_filename = str(max(vers))
+lv3_filename = "EUREC4A_JOANNE_Dropsonde-RD41_Level_3_v*.nc"
 
 
 def get_level3_dataset(lv3_directory=lv3_directory, lv3_filename=lv3_filename):
-    return xr.open_dataset(lv3_filename)
+    return xr.open_dataset(lv3_directory + lv3_filename)
 
 
 def get_circle_times_from_yaml(yaml_directory=yaml_directory):

--- a/joanne/Level_4/ready_ds_for_regression.py
+++ b/joanne/Level_4/ready_ds_for_regression.py
@@ -76,7 +76,7 @@ def get_circle_times_from_yaml(yaml_directory=yaml_directory):
     return sonde_ids, circle_times, flight_date, platform_name, segment_id
 
 
-def dim_ready_ds(ds_lv3=get_level3_dataset()):
+def dim_ready_ds(ds_lv3):
 
     dims_to_drop = ["sounding"]
 


### PR DESCRIPTION
The requirement of searching for the latest version of L3 files previously made it difficult to import `joanne.Level_4.ready_ds_for_regression` as a module, because the directories for L3 were hard-coded. To fix this, this requirement was removed with the assumption (or the demand) that the user provide only one L3 file in the directory. 

A subsequent function also called the `get_level3_dataset` function as default for the L3 directory. This default value has also been removed so as to not mess up the functioning of the module.

All these fixes should eventually become irrelevant with the introduction of a config file which would provide paths, rather than the hardcoded paths in the src files themselves. 

This PR is currently kept open as a potential way to include the solutions for providing paths too... (But I don't have the time to fix them now, so this is kept for a later revisit)