### PR TITLE
fix temperature description varname and unit

### DIFF
--- a/joanne/Level_3/README.md
+++ b/joanne/Level_3/README.md
@@ -70,7 +70,7 @@ Level-3 is a dataset where all Level-2 soundings are gridded to a uniform vertic
 |                 | `lat`             | North Latitude                                                 | degrees_north                         | sounding, height |
 |                 | `lon`             | East Longitude                                                 | degrees_east                          | sounding, height |
 | **Variables**   | `p`               | Atmospheric Pressure                                           | hPa                                   | sounding, height |
-|                 | `T`               | Dry Bulb Temperature                                           | degree_Celsius                        | sounding, height |
+|                 | `ta`              | Dry Bulb Temperature                                           | Kelvin                                | sounding, height |
 |                 | `rh`              | Relative Humidity                                              | %                                     | sounding, height |
 |                 | `wspd`            | Wind Speed                                                     | m s-1                                 | sounding, height |
 |                 | `wdir`            | Wind Direction                                                 | degrees                               | sounding, height |


### PR DESCRIPTION
Just a small fix of a discrepancy that I came across for the level 3 data description and the actual dataset.

This is based on JOANNE version 2.0.0 from the intake catalog. I couldn't find version 2.1.0 and verify if this issue persist for 2.1.0.